### PR TITLE
 Documentation for Sort Dictionary plugin #743

### DIFF
--- a/docs/flow/actions/sorted_dict_action.md
+++ b/docs/flow/actions/sorted_dict_action.md
@@ -1,0 +1,52 @@
+# Sort dictionary
+
+Sorts the referenced dictionary and returns it as a list of tuples of key and value.
+
+# Configuration
+
+Example:
+
+```json
+{
+  "data": {"first": 1, "second": 2, "fifth": 5, "third": 3},
+  "direction": "asc"
+}
+```
+
+This configuration will sort the dictionary
+
+```json
+{"first": 1, "second": 2, "fifth": 5, "third": 3}
+```
+
+with the order provided by direction (default: "asc")
+
+The dictionary is provided as a path to data in event. Example of such configuration.
+
+```json
+{
+  "data": "event@properties.data",
+  "direction": "asc",
+}
+```
+
+# Input
+
+This plugin does not process input.
+
+# Output
+
+Returns the ordered list of tuples with keys and values.
+
+Example:
+
+```json
+{
+  "result": [
+    ["first", 1], 
+    ["second", 2], 
+    ["third", 3], 
+    ["fifth", 5]
+  ]
+}
+```


### PR DESCRIPTION
Documentation for Sort Dictionary plugin Tracardi/tracardi#743

Created the documentation for the sort dictionary plugin.

Added the screenshot for reference.
![image](https://user-images.githubusercontent.com/101405993/196029337-26cb45ca-d8b5-4a97-bd2d-2bce8067a3b6.png)


We need your declaration that your contribution is MIT licensed without it, we can not merge your code.
To make clear that you license your contribution under the MIT you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licensed under the [MIT license](https://opensource.org/licenses/MIT)
